### PR TITLE
Change player speed to 0 on spawn instead of teleporting them each second

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -78,6 +78,7 @@ local stop_game = function()
 			minetest.set_player_privs(name, privs)
 			player:set_hp(20)
 			spawning.spawn(player, "lobby")
+			player:set_physics_override({speed=1})
 		end)
 	end
 	registrants = {}
@@ -144,6 +145,8 @@ local start_game_now = function(contestants)
 		privs.interact = true
 		privs.vote = nil
 		minetest.set_player_privs(name, privs)
+		player:set_physics_override({speed=1})
+--[[
 		minetest.after(0.1, function(table)
 			player = table[1]
 			i = table[2]
@@ -152,6 +155,7 @@ local start_game_now = function(contestants)
 				spawning.spawn(player, "player_"..i)
 			end
 		end, {player, i})
+]]
 	end
 	minetest.chat_send_all("The Hungry Games has begun!")
 	if hungry_games.grace_period > 0 then
@@ -194,6 +198,7 @@ local start_game = function()
 			if registrants[name] == true and spawning.is_spawn("player_"..i) then
 				table.insert(contestants, player)
 				spawning.spawn(player, "player_"..i)
+				player:set_physics_override({speed=0})
 				reset_player_state(player)
 			else
 				minetest.chat_send_player(name, "There are no spots for you to spawn!")
@@ -216,10 +221,6 @@ local start_game = function()
 					minetest.after(0.1, function(table)
 						player = table[1]
 						i = table[2]
-						local name = player:get_player_name()
-						if spawning.is_spawn("player_"..i) then
-							spawning.spawn(player, "player_"..i)
-						end
 					end, {player, i})
 				end
 			end, {contestants,i})
@@ -268,6 +269,7 @@ minetest.register_on_respawnplayer(function(player)
 	elseif (hungry_games.death_mode == "lobby") then
 		spawning.spawn(player, "lobby")
 	end
+	player:set_physics_override({speed=1})
 	return true
 end)
 
@@ -282,6 +284,7 @@ minetest.register_on_joinplayer(function(player)
 	minetest.set_player_privs(name, privs)
 	minetest.chat_send_player(name, "You are now spectating")
 	spawning.spawn(player, "lobby")
+	player:set_physics_override({speed=1})
 end)
 
 minetest.register_on_newplayer(function(player)

--- a/mods/hungry_games/init.lua
+++ b/mods/hungry_games/init.lua
@@ -35,7 +35,7 @@ glass_arena.replace({
 hungry_games = {}
 
 --Set countdown (in seconds) till players can leave their spawns.
-hungry_games.countdown = 10
+hungry_games.countdown = 60
 
 --Set grace period length in seconds (or 0 for no grace period)
 hungry_games.grace_period = 0


### PR DESCRIPTION
It always annoyed me that you can walk away from the start platform just to be teleported back to it; it also annoyed me other players doing this. It is especially annoying because this also resets the view.

So I have used `on_physics_override` to set the player speed to 0 while the start countdown is running.

**Warning**: This makes the Hungry Games likely to not work properly together with mods like [sprint] and other mods which use `on_physics_override` anymore! So think twice before you merge this.
