### PR TITLE
Fix chat being spammed with “get ready” messages

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -273,7 +273,6 @@ local start_game = function()
 			registrants[player:get_player_name()] = true
 			diff = diff - 1
 		end
-		minetest.chat_send_all("Get ready to fight!")
 		drop_player_items(player:get_player_name(), true)
 		minetest.after(0.1, function(list)
 			player = list[1]
@@ -283,6 +282,7 @@ local start_game = function()
 				table.insert(contestants, player)
 				spawning.spawn(player, "player_"..i)
 				reset_player_state(player)
+				minetest.chat_send_player(name, "Get ready to fight!")
 			else
 				minetest.chat_send_player(name, "There are no spots for you to spawn!")
 			end


### PR DESCRIPTION
The spam was spammed with “get ready” messages on start. This PR fixes this, now the message should only be shown once per player, and only to those who actually get a free spawn position.
