### PR TITLE
Fix crash on player joining and quickly leaving

### DIFF
--- a/mods/inventory_plus/init.lua
+++ b/mods/inventory_plus/init.lua
@@ -51,9 +51,11 @@ inventory_plus.set_inventory_formspec = function(player,formspec)
 	local privs = minetest.get_player_privs(player:get_player_name())
 	if privs.hg_maker then
 		-- if creative mode is on then wait a bit
-		minetest.after(0.1,function()
-			player:set_inventory_formspec(formspec)
-		end)
+		minetest.after(0.1,function(tbl)
+			if tbl.player ~= nil and tbl.player:is_player() then
+				tbl.player:set_inventory_formspec(tbl.formspec)
+			end
+		end, {player=player, formspec=formspec})
 	else
 		player:set_inventory_formspec(formspec)
 	end
@@ -202,9 +204,11 @@ minetest.register_on_joinplayer(function(player)
 		player:get_inventory():set_size("craft", 3*3)
 	end
 	local privs = minetest.get_player_privs(player:get_player_name())
-	minetest.after(1,function()
-		inventory_plus.set_inventory_formspec(player,inventory_plus.get_formspec(player, inventory_plus.default))
-	end)
+	minetest.after(1,function(player)
+		if player ~= nil and player:is_player() then
+			inventory_plus.set_inventory_formspec(player,inventory_plus.get_formspec(player, inventory_plus.default))
+		end
+	end, player)
 end)
 
 -- register_on_player_receive_fields


### PR DESCRIPTION
This fixes one possible cause for a server crash.

This particular crash happened when a player (new name) joined and quickly (<1 second) left the server again. The source of the crash was in `inventory_plus`. I have also reported the issue upstream.

The crash was cause because of careless `minetest.after` calls; if the player left within the time window (1 second), the `inventory_plus` functions attempted to do stuff with a player object of a player who does not exist anymore, thereby causing the crash.

The bugfix adds the missing sanity checks.
