### PR TITLE
Add maintenance mode

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -515,6 +515,10 @@ minetest.register_chatcommand("hg", {
 				minetest.chat_send_player(name, "At least 2 players are needed to start a new round.")
 				return
 			end
+			if get_spots() < 2 then
+				minetest.chat_send_player(name, "There are less than 2 active spawn positions. Please set new spawn positions with \"/hg set player_#\".")
+				return
+			end
 			local nostart
 			if starting_game or ingame then
 				nostart = true
@@ -533,6 +537,10 @@ minetest.register_chatcommand("hg", {
 			end
 			if num_players < 2 then
 				minetest.chat_send_player(name, "At least 2 players are needed to start a new round.")
+				return
+			end
+			if get_spots() < 2 then
+				minetest.chat_send_player(name, "There are less than 2 active spawn positions. Please set new spawn positions with \"/hg set player_#\".")
 				return
 			end
 			ret = start_game()
@@ -619,6 +627,10 @@ minetest.register_chatcommand("vote", {
 		local num = #players
 		if num < 2 then
 			minetest.chat_send_player(name, "At least 2 players are needed to start a new round.")
+			return
+		end
+		if get_spots() < 2 then
+			minetest.chat_send_player(name, "Spawn positions haven't been set yet. The game can not be started at the moment.")
 			return
 		end
 		if not ingame and not starting_game then

--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -19,6 +19,8 @@ local timer = nil
 local timer_updated = nil
 local timer_mode = nil	-- nil, "vote", "starting", "grace"
 
+local maintenance_mode = false		-- is true when server is in maintenance mode, no games can be started while in maintenance mode
+
 local update_timer_hud = function(text)
 	local players = minetest.get_connected_players()
 	for i=1,#players do
@@ -482,8 +484,8 @@ minetest.register_privilege("register", "Privilege to register.")
 
 --Hungry Games Chat Commands.
 minetest.register_chatcommand("hg", {
-	params = "start | restart | stop | build | set player_<n> | lobby | spawn",
-	description = "Manage Hungry Games. start: Start Hungry Games; restart: Restart Hungry Games; stop: Abort current game; build: Building mode to set up lobby, arena, etc.; set player_<n>: Set spawn position of player <n> (starting by 1); set lobby: Set spawn position in lobby; set spawn: Set initial spawn position for new players.",
+	params = "start | restart | stop | build | set player_<n> | lobby | spawn | maintenance",
+	description = "Manage Hungry Games. start: Start Hungry Games; restart: Restart Hungry Games; stop: Abort current game; build: Building mode to set up lobby, arena, etc.; set player_<n>: Set spawn position of player <n> (starting by 1); set lobby: Set spawn position in lobby; set spawn: Set initial spawn position for new players; maintenance: Toggle maintenance mode.",
 	privs = {hg_admin=true},
 	func = function(name, param)
 		--Catch param.
@@ -505,6 +507,10 @@ minetest.register_chatcommand("hg", {
 		local num_players  = #minetest.get_connected_players()
 		--Restarts/Starts game.
 		if parms[1] == "start" then
+			if maintenance_mode then
+				minetest.chat_send_player(name, "This server is currently in maintenance mode, no games can be started while it is in maintenance mode. Use \"/hg maintenance off\" to disable it.")
+				return
+			end
 			if num_players < 2 then
 				minetest.chat_send_player(name, "At least 2 players are needed to start a new round.")
 				return
@@ -518,6 +524,10 @@ minetest.register_chatcommand("hg", {
 				minetest.chat_send_player(name, "There is already a game running!")
 			end
 		elseif parms[1] == "restart" or parms[1] == 'r' then
+			if maintenance_mode then
+				minetest.chat_send_player(name, "This server is currently in maintenance mode, no games can be started while it is in maintenance mode. Use \"/hg maintenance off\" to disable it.")
+				return
+			end
 			if starting_game or ingame then
 				stop_game()
 			end
@@ -565,6 +575,32 @@ minetest.register_chatcommand("hg", {
 			else
 				minetest.chat_send_player(name, "Set what?")
 			end
+		elseif parms[1] == "maintenance" then
+			local maintenance_action
+			if parms[2] ~= nil then
+				if parms[2] == "on" then
+					maintenance_action = true
+				elseif parms[2] == "off" then
+					maintenance_action = false
+				end
+			else
+				maintenance_action = not maintenance_mode
+			end
+
+			if maintenance_action == true then
+				stop_game()
+				votes = 0
+				voters = {}
+				maintenance_mode = true
+				minetest.chat_send_all("This server is now in maintenance mode. The Hungry Games have been suspended until further notice.")
+			elseif maintenance_action == false then
+				votes = 0
+				voters = {}
+				maintenance_mode = false
+				minetest.chat_send_all("Server maintenance finished. The Hungry Games can begin!")
+			else
+				minetest.chat_send_player(name, "Invalid command syntax! Syntax: \"/hg maintenance [on|off]\"")
+			end
 		else
 			minetest.chat_send_player(name, "Unknown subcommand! Use /help hg for a list of available subcommands.")
 		end
@@ -575,6 +611,10 @@ minetest.register_chatcommand("vote", {
 	description = "Vote to start the Hungry Games.",
 	privs = {vote=true},
 	func = function(name, param)
+		if maintenance_mode then
+			minetest.chat_send_player(name, "This server is currently in maintenance mode, no games can be started at the moment. Please come back later when the server maintenance is over.")
+			return
+		end
 		local players = minetest.get_connected_players()
 		local num = #players
 		if num < 2 then


### PR DESCRIPTION
This is a way for server admins to manually forbid starting new games, this is useful when the map is being built and not supposed to be played at the moment.
As long as maintenance mode is active, voting is disabled, also `/hg start` and `/hg restart` won't work. Appropriate error messages will always be shown to the users.

Maintenance mode must always be activated or deactivated manually. Maintenance mode is deactivated when the server starts.

Use `/hg maintenance on` to put the server into maintenance mode. The current game will be immediately stopped (`stop_game`, which means all players are teleported to the lobby).
Use `/hg maintenance off` when you are finished with the maintenance.
Use `/hg maintenance` to toggle maintenance mode. (This is a shortcut for `on`/`off`.)
