### PR TITLE
Clear all inventories on stop_game

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -123,6 +123,7 @@ local stop_game = function()
 			privs.fly = nil
 			privs.interact = nil
 			minetest.set_player_privs(name, privs)
+			drop_player_items(name, true)
 			player:set_hp(20)
 			spawning.spawn(player, "lobby")
 		end)
@@ -162,7 +163,6 @@ local check_win = function()
 			end
 			
 			stop_game()
-			drop_player_items(winnerName, true)
 		end
 	end
 end


### PR DESCRIPTION
It was possible to end up carrying items in the lobby, for example, when the server operator called `/hg stop` manually.
Now each call to the `stop_game` function just clears all inventories.

Hopefully this reduces the amount of lobby griefing on your server as well. ;-)
