### PR TITLE
Some continuity fixes for when players leave

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -10,6 +10,7 @@ local voters = {}
 local currGame = {}
 local gameSequenceNumber = 0	--[[ Sequence number of current round, will be incremented each round.
 				     Used to determine whether minetest.after calls are still valid or should be discarded. ]]
+local voteSequenceNumber = 0
 
 local spots_shuffled = {}
 
@@ -469,6 +470,11 @@ minetest.register_on_leaveplayer(function(player)
    	local privs = minetest.get_player_privs(name)
 	if voters[name] and votes > 0 then
 		votes = votes - 1
+		voters[name] = nil
+	end
+	if votes < 2 and timer_mode == "vote" then
+		unset_timer()
+		minetest.chat_send_all("Automatic game start has been aborted; there are less than 2 votes.")
 	end
 	if registrants[name] then registrants[name] = nil end
 	minetest.after(1, function()
@@ -657,11 +663,12 @@ minetest.register_chatcommand("vote", {
 				minetest.chat_send_all("The match will automatically be initiated in " .. math.floor(hungry_games.vote_countdown/60) .. " minutes " .. math.fmod(hungry_games.vote_countdown, 60) .. " seconds.")
 				force_init_warning = true
 				set_timer("vote", hungry_games.vote_countdown)
-				minetest.after(hungry_games.vote_countdown, function (gsn) 
-					if not (starting_game or ingame and gsn == gameSequenceNumber) then
+				voteSequenceNumber = voteSequenceNumber + 1
+				minetest.after(hungry_games.vote_countdown, function (gsn, vsn)
+					if not (starting_game or ingame and gsn == gameSequenceNumber) and timer_mode == "vote" and voteSequenceNumber == vsn then
 						start_game()
 					end
-				end, gameSequenceNumber)
+				end, gameSequenceNumber, voteSequenceNumber)
 			end
 		else
 			minetest.chat_send_player(name, "Already ingame!")

--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -150,11 +150,9 @@ local check_win = function()
 		if count <= 1 then
 			local winnerName
 			for playerName,_ in pairs(currGame) do
-				local winnerPos = minetest.get_player_by_name(playerName):getpos()
-				winnerName = playerName
-				
-				minetest.chat_send_player(winnerName, "You Won!")
-				minetest.chat_send_all("The Hungry Games are now over, " .. winnerName .. " was the winner")
+				local winnerName = playerName
+				minetest.chat_send_player(winnerName, "You won!")
+				minetest.chat_send_all("The Hungry Games are now over, " .. winnerName .. " was the winner.")
 				minetest.sound_play("hungry_games_victory")
 			end
 		
@@ -165,6 +163,19 @@ local check_win = function()
 				minetest.set_player_privs(name, privs)
 			end
 			
+			stop_game()
+		end
+	elseif starting_game then
+		local players = minetest.get_connected_players()
+		if #players < 2 then
+			if #players == 1 then
+				local winnerName = players[1]:get_player_name()
+				minetest.chat_send_player(winnerName, "You won! (All other players have left.)")
+				minetest.sound_play("hungry_games_victory")
+
+				local privs = minetest.get_player_privs(winnerName)
+				minetest.set_player_privs(winnerName, privs)
+			end
 			stop_game()
 		end
 	end


### PR DESCRIPTION
I have found some rare corner cases and I seek to handle them properly.
Hungry Games had some inconsistent / bad behaviour when players leave at certain situations:
- The autostart/voting timer is running, 2 votes have been cast, but one of the voters leaves → less than 2 votes are remaining. If only 1 player is remaining when the timer ran out, the game could even start with only 1 player!
- All but 1 player leave during the starting period → The game continues with only 1 player

In the first case, I reset the vote of the one who leaves and stop the voting timer. For the timer to start again, there must be made more votes so that there are at least 2 of them.
In the second case, I automatically declare the remaining player as the winner and stop the game.
