### PR TITLE
Disable survival and damage when game is not running

### DIFF
--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -448,6 +448,7 @@ minetest.register_on_joinplayer(function(player)
 	minetest.set_player_privs(name, privs)
 	minetest.chat_send_player(name, "You are now spectating")
 	spawning.spawn(player, "lobby")
+	reset_player_state(player)
 	timer_hudids[name] = player:hud_add({
 		hud_elem_type = "text",
 		position = { x=0.5, y=0 },

--- a/mods/hungry_games/engine.lua
+++ b/mods/hungry_games/engine.lua
@@ -21,6 +21,10 @@ local timer_mode = nil	-- nil, "vote", "starting", "grace"
 
 local maintenance_mode = false		-- is true when server is in maintenance mode, no games can be started while in maintenance mode
 
+-- Initial setup
+minetest.setting_set("enable_damage", "false")
+survival.disable()
+
 local update_timer_hud = function(text)
 	local players = minetest.get_connected_players()
 	for i=1,#players do
@@ -137,6 +141,8 @@ local stop_game = function()
 	countdown = false
 	starting_game = false
 	force_init_warning = false
+	survival.disable()
+	minetest.setting_set("enable_damage", "false")
 	unset_timer()
 end
 
@@ -254,6 +260,7 @@ local start_game_now = function(input)
 		unset_timer()
 	end
 	minetest.setting_set("enable_damage", "true")
+	survival.enable()
 	votes = 0
 	voters = {}
 	ingame = true
@@ -419,7 +426,7 @@ minetest.register_on_dieplayer(function(player)
 end)
 
 minetest.register_on_respawnplayer(function(player)
-	player:set_hp(1)
+	player:set_hp(20)
 	local name = player:get_player_name()
    	local privs = minetest.get_player_privs(name)
    	if (privs.interact or privs.fly) and (hungry_games.death_mode == "spectate") then

--- a/mods/survival_modpack/survival_lib/init.lua
+++ b/mods/survival_modpack/survival_lib/init.lua
@@ -1,6 +1,6 @@
 
 survival = { };
-survival.active = true
+survival.active = false
 
 local player_states = { };
 local hudbar_active = {}
@@ -75,7 +75,9 @@ survival.disable = function()
             if (def.enabled) then
                 local name = def.name;
                 survival.reset_player_state(plname, name);
+                local state = player_states[plname][name];
                 if hudbar_active[plname] then
+                    hb.change_hudbar(player, name, math.floor(def.get_scaled_value(state)));
                     hb.hide_hudbar(player, name);
                 end
             end
@@ -133,20 +135,18 @@ minetest.register_globalstep(function ( dtime )
     local tmr = timer;
     timer = 0;
 
-    if survival.active then
-        for _,player in pairs(minetest.get_connected_players()) do
-            local inv = player:get_inventory();
-            local plname = player:get_player_name();
-            for i, def in ipairs(survival.registered_states) do
-                if (def.enabled) then
-                    local name = def.name;
-                    local state = player_states[plname][name];
-                    if (def.on_update) then
-                        def.on_update(tmr, player, state);
-                    end
-                    if hudbar_active[plname] then
-                        hb.change_hudbar(player, name, math.floor(def.get_scaled_value(state)));
-                    end
+    for _,player in pairs(minetest.get_connected_players()) do
+        local inv = player:get_inventory();
+        local plname = player:get_player_name();
+        for i, def in ipairs(survival.registered_states) do
+            if (def.enabled) then
+                local name = def.name;
+                local state = player_states[plname][name];
+                if (survival.active and def.on_update) then
+                    def.on_update(tmr, player, state);
+                end
+                if hudbar_active[plname] then
+                    hb.change_hudbar(player, name, math.floor(def.get_scaled_value(state)));
                 end
             end
         end


### PR DESCRIPTION
This PR makes the following changes:
- Disable survival (hunger/thirst) entirely while the game is not active
- Hides the hunger and thirst HUD bars while the game is not active
- Disables damage while the game is not active

So the screen does not get overcrowded in the lobby; most HUD bars are useless there, anyways. ;-)
